### PR TITLE
add sandbox and development to env prop options

### DIFF
--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -25,7 +25,7 @@ const PlaidLink = React.createClass({
 
     // The Plaid API environment on which to create user accounts.
     // For development and testing, use tartan. For production, use production
-    env: React.PropTypes.oneOf(['tartan', 'production']).isRequired,
+    env: React.PropTypes.oneOf(['tartan','sandbox','development','production']).isRequired,
 
     // Open link to a specific institution, for a more custom solution
     institution: React.PropTypes.string,


### PR DESCRIPTION
Getting an error due to the fact that there are now 3 environments and `tartan` is not one of them:

```
link.js:125 Error: Invalid env: "tartan". env must be "sandbox", "development" or "production".
    at error (link.js:337)
    at link.js:337
    at link.js:125
```

https://plaid.com/docs/api/